### PR TITLE
Added the fact that C# Examples are also available

### DIFF
--- a/articles/Examples.md
+++ b/articles/Examples.md
@@ -13,8 +13,8 @@ ms.devlang:   NA
 
 The [Tutorials/](https://github.com/Microsoft/CNTK/blob/master/Tutorials/) and
 [Examples/](https://github.com/Microsoft/CNTK/blob/master/Examples/) folders
-contain variety of example configurations for CNTK networks using both the
-Python API and BrainScript.
+contain variety of example configurations for CNTK networks using the
+Python API, BrainScript, and C# ([examples](./CNTK-CSharp-Examples.md) only).
 The examples are structured by topic into Image, Language Understanding,
 Speech, and so forth. To get started with CNTK we recommend the tutorials in
 the `Tutorials` folder.


### PR DESCRIPTION
It was mentioned in the first paragraph that examples are only for Python and Brainscript. Added the fact that C# examples are also available (Not tutorial though)