### PR TITLE
Remove invalid characters from link/image

### DIFF
--- a/articles/Object-Detection-using-Faster-R-CNN.md
+++ b/articles/Object-Detection-using-Faster-R-CNN.md
@@ -37,7 +37,7 @@ ms.devlang:   python
 The above are examples images and object annotations for the Grocery data set (left) and the Pascal VOC data set (right) used in this tutorial.
 
 _Faster R-CNN_ is an object detection algorithm proposed by _Shaoqing Ren, Kaiming He, Ross Girshick, and Jian Sun_ in 2015.
-The research paper is titled 'Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks', and is archived at [https://arxiv.org/abs/1506.01497]([https://arxiv.org/abs/1506.01497]).
+The research paper is titled 'Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks', and is archived at [https://arxiv.org/abs/1506.01497](https://arxiv.org/abs/1506.01497).
 Faster R-CNN builds on previous work to efficiently classify object proposals using deep convolutional networks. 
 Compared to previous work, Faster R-CNN employs a _region proposal network_ and does not require an external method for candidate region proposals.
 

--- a/articles/ReleaseNotes/CNTK_2_1_Release_Notes.md
+++ b/articles/ReleaseNotes/CNTK_2_1_Release_Notes.md
@@ -46,7 +46,7 @@ This release contains the following **breaking changes**:
 
 GPU editions of CNTK Version 2.1 on Windows and Linux are shipped with the [NVIDIA CUDA Deep Neural Network library (cuDNN) v.6.0](https://developer.nvidia.com/cudnn). This improves CNTK performance with networks like ResNet 50 by about 10%.
 
-If you build CNTK from source, you should also install NVIDIA cuDNN 6.0, since it is now the default for CNTK build and test on [Windows](https://docs.microsoft.com/en-us/cognitive-toolkit/Setup-CNTK-on-Windows#cudnn) and [Linux](https://docs.microsoft.com/en-us/cognitive-toolkit/Setup-CNTK-on-Linux#cudnn)).
+If you build CNTK from source, you should also install NVIDIA cuDNN 6.0, since it is now the default for CNTK build and test on [Windows](https://docs.microsoft.com/en-us/cognitive-toolkit/Setup-CNTK-on-Windows#cudnn) and [Linux](https://docs.microsoft.com/en-us/cognitive-toolkit/Setup-CNTK-on-Linux#cudnn).
 
 ### CNTK Evaluation library. Support of Universal Windows Platform (UWP)
 

--- a/articles/ReleaseNotes/CNTK_2_1_Release_Notes.md
+++ b/articles/ReleaseNotes/CNTK_2_1_Release_Notes.md
@@ -46,7 +46,7 @@ This release contains the following **breaking changes**:
 
 GPU editions of CNTK Version 2.1 on Windows and Linux are shipped with the [NVIDIA CUDA Deep Neural Network library (cuDNN) v.6.0](https://developer.nvidia.com/cudnn). This improves CNTK performance with networks like ResNet 50 by about 10%.
 
-If you build CNTK from source, you should also install NVIDIA cuDNN 6.0, since it is now the default for CNTK build and test on [Windows](https://docs.microsoft.com/en-us/cognitive-toolkit/Setup-CNTK-on-Windows#cudnn) and [Linux]((https://docs.microsoft.com/en-us/cognitive-toolkit/Setup-CNTK-on-Linux#cudnn)).
+If you build CNTK from source, you should also install NVIDIA cuDNN 6.0, since it is now the default for CNTK build and test on [Windows](https://docs.microsoft.com/en-us/cognitive-toolkit/Setup-CNTK-on-Windows#cudnn) and [Linux](https://docs.microsoft.com/en-us/cognitive-toolkit/Setup-CNTK-on-Linux#cudnn)).
 
 ### CNTK Evaluation library. Support of Universal Windows Platform (UWP)
 

--- a/articles/Setup-UWP-Build-on-Windows.md
+++ b/articles/Setup-UWP-Build-on-Windows.md
@@ -18,7 +18,7 @@ To build the CNTK configurations `Release_UWP` and `Debug_UWP` (for x64) in the 
 
 Open the Control Panel, then navigate to Programs -> Programs and Features. Select Visual Studio 2017, and click 'Change', when the Visual Studio setup starts, select Workloads `Universal Windows Platform Development` option
 
-![VS Setup](pictures\setup\VS2017Workloads.jpg)
+![VS Setup](pictures/setup/VS2017Workloads.jpg)
 
 This will take a few minutes to install.
 
@@ -58,4 +58,4 @@ UWP-specific tests are located in the `Tests\EndToEndTests\EvalClientTests\CNTKL
 
 Open Test Explorer window in Visual Studio. You should see a list of tests like this:
 
-![tests](pictures\setup\uwp-tests.png)
+![tests](pictures/setup/uwp-tests.png)


### PR DESCRIPTION
Backslash, extra brackets and square brackets will cause link/image invalid, it's better to avoid these cases in link/image.

This pull request is to fix above issue and unblock docfx v3 migration.