### PR TITLE
[BULK] DocuTune - Fix build validation issues: docs-link-absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # cognitive-toolkit-docs-pr
 
-Sources for Microsoft Cognitive Toolkit documentation hosted at https://docs.microsoft.com/en-us/cognitive-toolkit/.
+Sources for the [Microsoft Cognitive Toolkit documentation](https://docs.microsoft.com/en-us/cognitive-toolkit)/.

--- a/articles/Object-Detection-using-Faster-R-CNN.md
+++ b/articles/Object-Detection-using-Faster-R-CNN.md
@@ -255,7 +255,7 @@ Now you're set to train on the Pascal VOC 2007 data using `python run_faster_rcn
 
 ### Run Faster R-CNN on your own data
 
-Preparing your own data and annotating it with ground truth bounding boxes is described [here](https://docs.microsoft.com/en-us/cognitive-toolkit/Object-Detection-using-Fast-R-CNN#train-on-your-own-data).
+Preparing your own data and annotating it with ground truth bounding boxes is described in [Object detection using Fast R-CNN](/cognitive-toolkit/Object-Detection-using-Fast-R-CNN#train-on-your-own-data).
 After storing your images in the described folder structure and annotating them please run
 
 `python Examples/Image/Detection/utils/annotations/annotations_helper.py`

--- a/articles/ReleaseNotes/CNTK_2_0_Release_Notes.md
+++ b/articles/ReleaseNotes/CNTK_2_0_Release_Notes.md
@@ -21,7 +21,7 @@ This is the first production release of the Microsoft Cognitive Toolkit V2. We w
 
 ### CNTK backend for Keras
 
-We are happy to bring CNTK as a backend for Keras as a beta release to our fans asking for this feature. While there is still feature and performance work remaining to be done, we appreciate early feedback that would help us bake Keras support. For installation instructions and additional details see [this page](https://docs.microsoft.com/en-us/cognitive-toolkit/Using-CNTK-with-Keras).
+We are happy to bring CNTK as a backend for Keras as a beta release to our fans asking for this feature. While there is still feature and performance work remaining to be done, we appreciate early feedback that would help us bake Keras support. For installation instructions and additional details, see [Using CNTK with Keras](/cognitive-toolkit/Using-CNTK-with-Keras).
 
 ### Binary convolution with Halide
 
@@ -29,7 +29,7 @@ This release includes [an example](https://github.com/Microsoft/CNTK/tree/releas
 
 ### CNTK Java API
 
-Starting from CNTK V.2.0 RC 3, a Java API is added to support model evaluation in Java on Windows and Linux. Note that the API is still *experimental* and subject to change. Feedback from the community is greatly appreciated. See the details at [this page](https://docs.microsoft.com/en-us/cognitive-toolkit/CNTK-Library-API#java-api-experimental).
+Starting from CNTK V.2.0 RC 3, a Java API is added to support model evaluation in Java on Windows and Linux. Note that the API is still *experimental* and subject to change. Feedback from the community is greatly appreciated. See the details at [this page](/cognitive-toolkit/CNTK-Library-API#java-api-experimental).
 
 ### New additional features
 

--- a/articles/ReleaseNotes/CNTK_2_1_Release_Notes.md
+++ b/articles/ReleaseNotes/CNTK_2_1_Release_Notes.md
@@ -46,15 +46,15 @@ This release contains the following **breaking changes**:
 
 GPU editions of CNTK Version 2.1 on Windows and Linux are shipped with the [NVIDIA CUDA Deep Neural Network library (cuDNN) v.6.0](https://developer.nvidia.com/cudnn). This improves CNTK performance with networks like ResNet 50 by about 10%.
 
-If you build CNTK from source, you should also install NVIDIA cuDNN 6.0, since it is now the default for CNTK build and test on [Windows](https://docs.microsoft.com/en-us/cognitive-toolkit/Setup-CNTK-on-Windows#cudnn) and [Linux](https://docs.microsoft.com/en-us/cognitive-toolkit/Setup-CNTK-on-Linux#cudnn).
+If you build CNTK from source, you should also install NVIDIA cuDNN 6.0, since it is now the default for CNTK build and test on [Windows](/cognitive-toolkit/Setup-CNTK-on-Windows#cudnn) and [Linux](/cognitive-toolkit/Setup-CNTK-on-Linux#cudnn).
 
 ### CNTK Evaluation library. Support of Universal Windows Platform (UWP)
 
-With this release we introduce the support of [Universal Windows Platform (UWP)](https://docs.microsoft.com/en-us/windows/uwp/get-started/whats-a-uwp). A new CNTK NuGet Package *[CNTK, UWP CPU-Only Build](http://www.nuget.org/packages/CNTK.UWP.CPUOnly)* is available for download. For further details see the description of [Model Evaluation on Universal Windows Platform](https://docs.microsoft.com/en-us/cognitive-toolkit/CNTK-Library-Evaluation-on-UWP). To build the CNTK UWP evaluation library, see the description [here](https://docs.microsoft.com/en-us/cognitive-toolkit/Setup-UWP-Build-on-Windows).
+With this release we introduce the support of [Universal Windows Platform (UWP)](/windows/uwp/get-started/whats-a-uwp). A new CNTK NuGet Package *[CNTK, UWP CPU-Only Build](http://www.nuget.org/packages/CNTK.UWP.CPUOnly)* is available for download. For further details see the description of [Model Evaluation on Universal Windows Platform](/cognitive-toolkit/CNTK-Library-Evaluation-on-UWP). To build the CNTK UWP evaluation library, see the description [here](/cognitive-toolkit/Setup-UWP-Build-on-Windows).
 
 ### CNTK backend for Keras
 
-Version 2.1 introduces the following improvements for the [CNTK backend for Keras](https://docs.microsoft.com/en-us/cognitive-toolkit/Using-CNTK-with-Keras):
+Version 2.1 introduces the following improvements for the [CNTK backend for Keras](/cognitive-toolkit/Using-CNTK-with-Keras):
 
 * Stateful recurrent network support
 * Support of Recurrent layer with mask
@@ -64,7 +64,7 @@ Version 2.1 introduces the following improvements for the [CNTK backend for Kera
 
 * ResNet 50 performance improvement (reduce memcpy and memset during training). Expect single machine training speed to improve by about 8%
 * Improvements in CNTK reader by index caching
-* We have successfully tested CNTK ability to train ResNet 50 and Inception V3 with large minibatch size as the proposed in a [recent paper]( https://research.fb.com/publications/imagenet1kin1h/). This confirms CNTK ability of minibatch scaling not only for speech, but for image tasks as well
+* We have successfully tested CNTK ability to train ResNet 50 and Inception V3 with large minibatch size as the proposed in a [recent paper](https://research.fb.com/publications/imagenet1kin1h/). This confirms CNTK ability of minibatch scaling not only for speech, but for image tasks as well
 
 ### New manuals, tutorials, examples and courses
 
@@ -82,7 +82,7 @@ Version 2.1 introduces the following improvements for the [CNTK backend for Kera
 * [Training Acoustic Model with Connectionist Temporal Classification (CTC) Criteria](https://github.com/Microsoft/CNTK/tree/release/2.1/Tutorials/CNTK_208_Speech_Connectionist_Temporal_Classification.ipynb)
 * [Flapping Bird using Keras and Reinforcement Learning](https://github.com/Microsoft/CNTK/tree/release/2.1/Examples/ReinforcementLearning/FlappingBirdWithKeras)
 * [Faster R-CNN object detection](https://github.com/Microsoft/CNTK/tree/release/2.1/Examples/Image/Detection/FasterRCNN)
-* [Using CNTK V2 API in Azure WebAPI for model evaluation](https://docs.microsoft.com/en-us/cognitive-toolkit/Evaluate-a-model-in-an-Azure-WebApi)
+* [Using CNTK V2 API in Azure WebAPI for model evaluation](/cognitive-toolkit/Evaluate-a-model-in-an-Azure-WebApi)
 * [CVPR 2017](http://cvpr2017.thecvf.com/program/tutorials) - July 26, 2017, Tutorial by *Emad Barsoum*, *Sayan Pathak* and *Cha Zhang*, Scalable Deep Learning with Microsoft Cognitive Toolkit. [Presentation](https://www.cntk.ai/Tutorials/CVPR2017/CVPR_2017_Tutorial_final.pdf)
 
 ### Bug fixes

--- a/articles/ReleaseNotes/CNTK_2_2_Release_Notes.md
+++ b/articles/ReleaseNotes/CNTK_2_2_Release_Notes.md
@@ -21,7 +21,7 @@ ms.devlang:   NA
 We have added HTML versions of the [tutorials](https://www.cntk.ai/pythondocs/tutorials.html) and [manuals](https://www.cntk.ai/pythondocs/manuals.html) with the [Python documentation](https://www.cntk.ai/pythondocs/). This makes the [tutorial notebooks](https://www.cntk.ai/pythondocs/tutorials.html) and manuals searchable as well.
 
 ### Updated evaluation documents
-Documents related to model evaluation have been updated. Please check the latest documents [here](https://docs.microsoft.com/en-us/cognitive-toolkit/CNTK-Evaluation-Overview).
+Documents related to model evaluation have been updated. Please check the latest documents at [CNTK evaluation overview](/cognitive-toolkit/CNTK-Evaluation-Overview).
 
 ## System
 
@@ -29,7 +29,7 @@ Documents related to model evaluation have been updated. Please check the latest
 This work is rolled over into next release due to dependency on test infrastructure updates.
 
 ### Support for NCCL 2
-Now [NCCL](https://developer.nvidia.com/nccl) can be used across machines. User need to enable NCCL in build configure as [here](https://docs.microsoft.com/en-us/cognitive-toolkit/setup-cntk-on-linux).
+Now [NCCL](https://developer.nvidia.com/nccl) can be used across machines. User need to enable NCCL in build configure as [here](/cognitive-toolkit/setup-cntk-on-linux).
 Note:
 * After installed the downloaded NCCL 2 package, there are two packages:
 ```
@@ -153,16 +153,17 @@ https://github.com/Microsoft/CNTK/tree/release/latest/Examples/TrainingCSharp/Co
 R-binding for CNTK, which enables both training and evaluation, will be published in a separate repository very soon.
 
 ## Examples
+
 ### Object Detection with Fast R-CNN and Faster R-CNN
 * Support for bounding box regression and VGG model in Fast R-CNN.
-* New tutorial in documentation on [Faster R-CNN object detection](https://docs.microsoft.com/en-us/cognitive-toolkit/Object-Detection-using-Faster-R-CNN) and updated tutorial on [Fast R-CNN](https://docs.microsoft.com/en-us/cognitive-toolkit/Object-Detection-using-Fast-R-CNN).
+* New tutorial in documentation on [Faster R-CNN object detection](/cognitive-toolkit/Object-Detection-using-Faster-R-CNN) and updated tutorial on [Fast R-CNN](/cognitive-toolkit/Object-Detection-using-Fast-R-CNN).
 * [Object detection demo script](https://github.com/Microsoft/CNTK/tree/release/latest/Examples/Image/Detection) that allows to choose different detectors, base models, and data sets.
 
 ### New C++ Eval Examples
 We added new C++ examples [`CNTKLibraryCPPEvalCPUOnlyExamples`](https://github.com/Microsoft/CNTK/tree/release/2.2/Examples/Evaluation/CNTKLibraryCPPEvalCPUOnlyExamples) and [`CNTKLibraryCPPEvalGPUExamples`](https://github.com/Microsoft/CNTK/tree/release/2.2/Examples/Evaluation/CNTKLibraryCPPEvalGPUExamples). They illustrate how to use C++ CNTK Library for model evaluation on CPU and GPU. Another new example is [UWPImageRecognition](https://github.com/Microsoft/CNTK/tree/release/2.2/Examples/Evaluation/UWPImageRecognition), which is an example using CNTK UWP library for model evaluation.
 
 ### New C# Eval examples
-We added an example for asynchronous evaluation:  [`EvaluationSingleImageAsync()`](https://github.com/Microsoft/CNTK/tree/release/2.2/Examples/Evaluation/CNTKLibraryCSEvalCPUOnlyExamples/CNTKLibraryCSEvalExamples.cs). One thing we shall point out is CNTK C# API does not have an asynchronous method for Evaluate(), because the evaluation is a CPU-bound operation (Please refer to [this article](https://blogs.msdn.microsoft.com/pfxteam/2012/03/24/should-i-expose-asynchronous-wrappers-for-synchronous-methods/) for detailed explanation). However, it is desired to run evaluation asynchronously in some use cases, e.g. offloading for responsiveness, we show in the example [`EvaluationSingleImageAsync()`](https://github.com/Microsoft/CNTK/tree/release/2.2/Examples/Evaluation/CNTKLibraryCSEvalCPUOnlyExamples/CNTKLibraryCSEvalExamples.cs) how to achieve that by using the extension method [`EvaluateAsync()`](https://github.com/Microsoft/CNTK/tree/release/2.2/Examples/Evaluation/CNTKLibraryCSEvalCPUOnlyExamples/CNTKExtensions.cs). Please refer to the section *Run evaluation asynchronously* on the page [Using C#/.NET Managed API](https://docs.microsoft.com/en-us/cognitive-toolkit/CNTK-Library-Evaluation-on-Windows#using-cnet-managed-api) for details.
+We added an example for asynchronous evaluation: [`EvaluationSingleImageAsync()`](https://github.com/Microsoft/CNTK/tree/release/2.2/Examples/Evaluation/CNTKLibraryCSEvalCPUOnlyExamples/CNTKLibraryCSEvalExamples.cs). One thing we shall point out is CNTK C# API does not have an asynchronous method for Evaluate(), because the evaluation is a CPU-bound operation (Please refer to [Should I expose asynchronous wrappers for synchronous methods?](https://devblogs.microsoft.com/pfxteam/should-i-expose-asynchronous-wrappers-for-synchronous-methods/) for detailed explanation). However, it is desired to run evaluation asynchronously in some use cases, such as offloading for responsiveness, we show in the example [`EvaluationSingleImageAsync()`](https://github.com/Microsoft/CNTK/tree/release/2.2/Examples/Evaluation/CNTKLibraryCSEvalCPUOnlyExamples/CNTKLibraryCSEvalExamples.cs) how to achieve that by using the extension method [`EvaluateAsync()`](https://github.com/Microsoft/CNTK/tree/release/2.2/Examples/Evaluation/CNTKLibraryCSEvalCPUOnlyExamples/CNTKExtensions.cs). Please refer to the section *Run evaluation asynchronously* on the page [Using C#/.NET Managed API](/cognitive-toolkit/CNTK-Library-Evaluation-on-Windows#using-cnet-managed-api) for details.
 * Evaluating intermediate layers: [`EvaluateIntermediateLayer()`](https://github.com/Microsoft/CNTK/tree/release/2.2/Examples/Evaluation/CNTKLibraryCSEvalCPUOnlyExamples/CNTKLibraryCSEvalExamples.cs)
 * Evaluating outputs from multiple nodes: [`EvaluateCombinedOutputs()`](https://github.com/Microsoft/CNTK/tree/release/2.2/Examples/Evaluation/CNTKLibraryCSEvalCPUOnlyExamples/CNTKLibraryCSEvalExamples.cs)
 
@@ -220,11 +221,11 @@ This work is rolled over to next release due to dependency on test infrastructur
 ## Keras and Tensorboard
 ### Multi-GPU support for Keras on CNTK.
 
-We added an article to elaborated how to conduct parallel training on CNTK with Keras. Details are [here](http://docs.microsoft.com/en-us/cognitive-toolkit/Using-CNTK-MultiGPU-Support-with-Keras).
+We added an article to elaborated how to conduct parallel training on CNTK with Keras. For more information, see [CNTK Multi-GPU Support with Keras](/cognitive-toolkit/Using-CNTK-MultiGPU-Support-with-Keras).
 
 ### Tensorboard image support for CNTK.
 
-We added the image feature support for TensorBoard. Now CNTK users can use TensorBoard to display images. More details and examples can be found [here](http://docs.microsoft.com/en-us/cognitive-toolkit/Using-TensorBoard-for-Visualization).
+We added the image feature support for TensorBoard. Now CNTK users can use TensorBoard to display images. More details and examples can be found [here](/cognitive-toolkit/Using-TensorBoard-for-Visualization).
 
 ### Acknowledgments
 We thank the following community members for their contributions:+
@@ -245,7 +246,6 @@ We thank the following community members for their contributions:+
 * [@StillKeepTry](https://github.com/StillKeepTry)
 * [@taehoonlee](https://github.com/taehoonlee)
 * [@vmazalov](https://github.com/vmazalov)
-
 
 We apologize for any community contributions we might have overlooked in these release notes.
 

--- a/articles/Serialization.md
+++ b/articles/Serialization.md
@@ -18,15 +18,16 @@ This article goes over saving and loading models and checkpointing during traini
 ### Save model
 
 To save a model to file, use the [`save()`](https://cntk.ai/pythondocs/cntk.ops.functions.html#cntk.ops.functions.Function.save) function and specify a filepath for the saved model.
+
 ```Python
 import cntk as C
 
 x = C.input_variable(<input shape>)
 z = create_model(x) #user-defined 
 z.save("myModel.model")
-``` 
+```
 
-Note that a model saved in this way using the the [CNTK Library API](https://docs.microsoft.com/en-us/cognitive-toolkit/cntk-library-api) will have the model-v2 format. The model-v2 format is a Protobuf-based model serialization format, introduced in CNTK v2. (For more information, refer to [CNTK Model Format](https://docs.microsoft.com/en-us/cognitive-toolkit/CNTK-model-format).) While any file extension can be used (and you may see the use of various file extensions such as `.model`, `.dnn`, `.cmf` across CNTK documentation), we recommend that you stick to the convention of using `.model` for your CNTK models.
+Note that a model saved in this way using the[CNTK Library API](/cognitive-toolkit/cntk-library-api) will have the model-v2 format. The model-v2 format is a Protobuf-based model serialization format, introduced in CNTK v2. (For more information, refer to [CNTK model format](/cognitive-toolkit/CNTK-model-format).) While any file extension can be used (and you may see the use of various file extensions such as `.model`, `.dnn`, `.cmf` across CNTK documentation), we recommend that you stick to the convention of using `.model` for your CNTK models.
 
 ### Load model
 To load a model from file into CNTK:
@@ -41,8 +42,8 @@ z = C.Function.load("myModel.model")
 ```
 ### Related resources
 The following examples include some commonly performed tasks involving the saving and loading of trained models.
-* [Evaluate a saved trained model](https://docs.microsoft.com/en-us/cognitive-toolkit/How-do-I-Evaluate-models-in-Python#evaluate-a-saved-convolutional-network)
-* [Access the parameters of a saved trained model](https://docs.microsoft.com/en-us/cognitive-toolkit/How-do-I-Read-Things-in-Python#load-model-and-access-network-weights-parameters)
+* [Evaluate a saved trained model](/cognitive-toolkit/How-do-I-Evaluate-models-in-Python#evaluate-a-saved-convolutional-network)
+* [Access the parameters of a saved trained model](/cognitive-toolkit/How-do-I-Read-Things-in-Python#load-model-and-access-network-weights-parameters)
 * [Evaluate and write out specific layers of a saved trained model](https://github.com/Microsoft/CNTK/tree/release/latest/Examples/Image/FeatureExtraction)  
 
 ### ONNX format


### PR DESCRIPTION
**Global effort to fix build validation errors**

The Microsoft Skilling team is fixing build validation errors and specific brand inconsistencies in Microsoft technical documentation for the rest of FY23 Q1. This will help address various accessibility, security, and usability issues. This PR was generated using DocuTune. It includes only targeted fixes and minor formatting adjustments.

DocuTune PRs improve quality of technical content by finding and automatically correcting a broad set of issues only where the correction is suitable. Please review within five business days and merge or comment in the PR with any changes you'd like to see. Thank you!

CorrelationId: 0df9c2d6-63f8-4d1e-8b57-b33611a06514
InitiativeId: docutune-build-validation-issues-2022-05
PointOfContact: Alex Buck
